### PR TITLE
Add time-to-destination display.

### DIFF
--- a/src/gamestate.cpp
+++ b/src/gamestate.cpp
@@ -481,6 +481,46 @@ std::vector<Coord> CharacterState::DumpPath(const std::vector<Coord> *alternativ
     return ret;
 }
 
+/**
+ * Calculate total length (in the same L-infinity sense that gives the
+ * actual movement time) of the outstanding path.
+ * @param altWP Optionally provide alternative waypoints (for queued moves).
+ * @return Time necessary to finish current path in blocks.
+ */
+unsigned
+CharacterState::TimeToDestination (const WaypointVector* altWP) const
+{
+  bool reverse = false;
+  if (!altWP)
+    {
+      altWP = &waypoints;
+      reverse = true;
+    }
+
+  /* In order to handle both reverse and non-reverse correctly, calculate
+     first the length of the path alone and only later take the initial
+     piece from coord on into account.  */
+
+  if (altWP->empty ())
+    return 0;
+
+  unsigned res = 0;
+  WaypointVector::const_iterator i = altWP->begin ();
+  Coord last = *i;
+  for (++i; i != altWP->end (); ++i)
+    {
+      res += distLInf (last, *i);
+      last = *i;
+    }
+
+  if (reverse)
+    res += distLInf (coord, altWP->back ());
+  else
+    res += distLInf (coord, altWP->front ());
+
+  return res;
+}
+
 void PlayerState::SpawnCharacter(RandomGenerator &rnd)
 {
     characters[next_character_index++].Spawn(color, rnd);

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -95,6 +95,8 @@ struct Coord
     bool operator>=(const Coord &that) const { return !(*this < that); }
 };
 
+typedef std::vector<Coord> WaypointVector;
+
 struct Move
 {
     PlayerID player;
@@ -105,7 +107,7 @@ struct Move
     boost::optional<std::string> addressLock;
 
     unsigned char color;   // For spawn move
-    std::map<int, std::vector<Coord> > waypoints;
+    std::map<int, WaypointVector> waypoints;
     std::set<int> destruct;
 
     Move() : color(0xFF)
@@ -191,7 +193,7 @@ struct CharacterState
     Coord coord;                        // Current coordinate
     unsigned char dir;                  // Direction of last move (for nice sprite orientation). Encoding: as on numeric keypad.
     Coord from;                         // Straight-line pathfinding for current waypoint
-    std::vector<Coord> waypoints;       // Waypoints (stored in reverse so removal of the first waypoint is fast)
+    WaypointVector waypoints;           // Waypoints (stored in reverse so removal of the first waypoint is fast)
     CollectedLootInfo loot;             // Loot collected by player but not banked yet
     unsigned char stay_in_spawn_area;   // Auto-kill players who stay in the spawn area too long
     std::string attack;
@@ -218,7 +220,15 @@ struct CharacterState
     }
 
     void MoveTowardsWaypoint();
-    std::vector<Coord> DumpPath(const std::vector<Coord> *alternative_waypoints = NULL) const;
+    WaypointVector DumpPath(const WaypointVector *alternative_waypoints = NULL) const;
+
+    /**
+     * Calculate total length (in the same L-infinity sense that gives the
+     * actual movement time) of the outstanding path.
+     * @param altWP Optionally provide alternative waypoints (for queued moves).
+     * @return Time necessary to finish current path in blocks.
+     */
+    unsigned TimeToDestination(const WaypointVector *altWP = NULL) const;
 
     json_spirit::Value ToJsonValue(bool has_crown) const;
 };

--- a/src/qt/gamemovecreator.h
+++ b/src/qt/gamemovecreator.h
@@ -10,7 +10,7 @@ std::vector<Game::Coord> FindPath(const Game::Coord &start, const Game::Coord &g
 
 struct QueuedMove
 {
-    std::vector<Game::Coord> waypoints;
+    Game::WaypointVector waypoints;
     bool destruct;
 
     QueuedMove() : destruct(false) { }

--- a/src/qt/managenamespage.cpp
+++ b/src/qt/managenamespage.cpp
@@ -136,7 +136,17 @@ public:
                             return tr("Moving");
                     }
                 case Time:
-                    return tr("Unknown");
+                    unsigned val = 0;
+                    mi = queuedMoves.find(i);
+                    mi2 = state.characters.find(i);
+                    const Game::WaypointVector* wp = NULL;
+                    if (mi != queuedMoves.end())
+                        wp = &mi->second.waypoints;
+                    if (mi2 != state.characters.end())
+                        val = mi2->second.TimeToDestination(wp);
+                    if (val > 0)
+                        return QString("%1").arg(val);
+                    return "";
             }
         }
         else if (role == Qt::TextAlignmentRole)


### PR DESCRIPTION
This adds a "time-to-destination" display to the player table when players are moving or queued.  I only tested the calculation on few cases, but I hope it is correct both for moving and queued players.  Also note that I didn't touch any "critical" code where problematic bugs could have been introduced (at least that's my opinion).
