### PR TITLE
Catch exceptions correctly in async RPC calls.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -3696,6 +3696,10 @@ ExecuteRpcCall (ClientConnectionOutput* out, rpcfn_type method,
       string strReply = JSONRPCReply (result, json_spirit::Value::null, id);
       out->getStream () << HTTPReply (200, strReply) << std::flush;
     }
+  catch (Object& objError)
+    {
+      ErrorReply (out->getStream (), objError, id);
+    }
   catch (const boost::thread_interrupted& e)
     {
       ErrorReply (out->getStream (),


### PR DESCRIPTION
Fix a segfault if RPC calls return an error.
