### PR TITLE
Mitigates boost/spirit json crash

### DIFF
--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -34,6 +34,9 @@ map<vector<unsigned char>, set<uint256> > mapNamePending;
 boost::mutex mut_currentState;
 boost::condition_variable cv_stateChange;
 
+boost::mutex json_spirit::mtx_parser;
+
+
 #ifdef GUI
 extern std::map<uint160, std::vector<unsigned char> > mapMyNameHashes;
 #endif

--- a/src/json/json_spirit_reader_template.h
+++ b/src/json/json_spirit_reader_template.h
@@ -513,17 +513,24 @@ namespace json_spirit
 
         Semantic_actions_t& actions_;
     };
+    
+    extern boost::mutex mtx_parser;
 
     template< class Iter_type, class Value_type >
     Iter_type read_range_or_throw( Iter_type begin, Iter_type end, Value_type& value )
     {
+    
+    //boost::lock_guard<boost::mutex> lock(_mtx)
+    
+        mtx_parser.lock();
         Semantic_actions< Value_type, Iter_type > semantic_actions( value );
-     
+        Json_grammer< Value_type, Iter_type > *jg = new Json_grammer< Value_type, Iter_type>( semantic_actions );
         const spirit_namespace::parse_info< Iter_type > info = 
-                            spirit_namespace::parse( begin, end, 
-                                                    Json_grammer< Value_type, Iter_type >( semantic_actions ), 
+                            spirit_namespace::parse( begin, end, *jg, 
                                                     spirit_namespace::space_p );
-
+        delete jg;
+        mtx_parser.unlock();
+        
         if( !info.hit )
         {
             assert( false ); // in theory exception should already have been thrown


### PR DESCRIPTION
This is a somewhat "rough around the edges" solution.

This introduces a global mutex around "read_range_or_throw" in boost/spirit headers.  This mitigates (but does not entirely resolve) most of the parsing related crashing from getwork, getworkaux, etc occurring on the rpc thread at the same time as other parsing.

These crashes are a known-issue with the Spirit json headers, but is more or less considered "wontfix" by the boost team - pending a port of the parser to Spirit2.  For more information see https://svn.boost.org/trac/boost/ticket/5520

We are working on another patch to replace the parser in use entirely, which should not only resolve all of the parsing related issue but also offer some performance benefits.

This work should also (eventually) be communicated upstream to NMC.
