### PR TITLE
Reduce debug chatter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -525,7 +525,9 @@ bool CTransaction::AcceptToMemoryPool(CTxDB& txdb, bool fCheckInputs, bool fLimi
     if (ptxOld)
         EraseFromWallets(ptxOld->GetHash());
 
-    printf("AcceptToMemoryPool(): accepted %s\n", hash.ToString().substr(0,10).c_str());
+    if (fDebug)
+        printf("AcceptToMemoryPool(): accepted %s\n",
+               hash.ToString().substr(0,10).c_str());
     return true;
 }
 
@@ -2239,8 +2241,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
     static map<unsigned int, vector<unsigned char> > mapReuseKey;
     RandAddSeedPerfmon();
     if (fDebug)
+    {
         printf("%s ", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
-    printf("received: %s (%d bytes)\n", strCommand.c_str(), vRecv.size());
+        printf("received: %s (%d bytes)\n", strCommand.c_str(), vRecv.size());
+    }
+
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         printf("dropmessagestest DROPPING RECV MESSAGE\n");
@@ -2416,7 +2421,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             pfrom->AddInventoryKnown(inv);
 
             bool fAlreadyHave = AlreadyHave(txdb, inv);
-            printf("  got inventory: %s  %s\n", inv.ToString().c_str(), fAlreadyHave ? "have" : "new");
+            if (fDebug)
+                printf("  got inventory: %s  %s\n",
+                       inv.ToString().c_str(), fAlreadyHave ? "have" : "new");
 
             if (!fAlreadyHave)
                 pfrom->AskFor(inv);
@@ -2440,7 +2447,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         {
             if (fShutdown)
                 return true;
-            printf("received getdata for: %s\n", inv.ToString().c_str());
+            if (fDebug)
+                printf("received getdata for: %s\n", inv.ToString().c_str());
 
             if (inv.type == MSG_BLOCK)
             {
@@ -3022,7 +3030,9 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             const CInv& inv = (*pto->mapAskFor.begin()).second;
             if (!AlreadyHave(txdb, inv))
             {
-                printf("sending getdata: %s\n", inv.ToString().c_str());
+                if (fDebug)
+                    printf("sending getdata: %s\n", inv.ToString().c_str());
+
                 vGetData.push_back(inv);
                 if (vGetData.size() >= 1000)
                 {

--- a/src/net.h
+++ b/src/net.h
@@ -653,7 +653,9 @@ public:
         // We're using mapAskFor as a priority queue,
         // the key is the earliest time the request can be sent
         int64& nRequestTime = mapAlreadyAskedFor[inv];
-        printf("askfor %s   %"PRI64d"\n", inv.ToString().c_str(), nRequestTime);
+        if (fDebug)
+            printf("askfor %s   %"PRI64d"\n",
+                   inv.ToString().c_str(), nRequestTime);
 
         // Make sure not to reuse time indexes to keep things in the same order
         int64 nNow = (GetTime() - 1) * 1000000;
@@ -676,8 +678,10 @@ public:
         vSend << CMessageHeader(pszCommand, 0);
         nMessageStart = vSend.size();
         if (fDebug)
+        {
             printf("%s ", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
-        printf("sending: %s ", pszCommand);
+            printf("sending: %s ", pszCommand);
+        }
     }
 
     void AbortMessage()
@@ -688,7 +692,9 @@ public:
         nHeaderStart = -1;
         nMessageStart = -1;
         cs_vSend.Leave();
-        printf("(aborted)\n");
+
+        if (fDebug)
+            printf("(aborted)\n");
     }
 
     void EndMessage()
@@ -714,8 +720,8 @@ public:
         assert(nMessageStart - nHeaderStart >= offsetof(CMessageHeader, nChecksum) + sizeof(nChecksum));
         memcpy((char*)&vSend[nHeaderStart] + offsetof(CMessageHeader, nChecksum), &nChecksum, sizeof(nChecksum));
 
-        printf("(%d bytes) ", nSize);
-        printf("\n");
+        if (fDebug)
+            printf("(%d bytes)\n", nSize);
 
         nHeaderStart = -1;
         nMessageStart = -1;


### PR DESCRIPTION
This removes some of the most common outputs to debug.log, bringing the level of output down drastically.  Using -debug or debug=1, the output can be re-enabled for debugging.  Since this is the express purpose of this flag, I think it makes sense to _not_ show excessive logs when debugging mode is not enabled.
