### PR TITLE
Show player path always on top.

### DIFF
--- a/src/qt/gamemapview.cpp
+++ b/src/qt/gamemapview.cpp
@@ -593,12 +593,12 @@ void GameMapView::SelectPlayer(const QString &name, const GameState &state, Queu
     if (!path.isEmpty())
     {
         playerPath = scene->addPath(path, grobjs->magenta_pen);
-        playerPath->setZValue(0.5);
+        playerPath->setZValue(1e9 + 1);
     }
     if (!queuedPath.isEmpty())
     {
         queuedPlayerPath = scene->addPath(queuedPath, grobjs->gray_pen);
-        queuedPlayerPath->setZValue(0.6);
+        queuedPlayerPath->setZValue(1e9 + 2);
     }
 
     use_cross_cursor = true;


### PR DESCRIPTION
This patch puts the player paths always on top of the map drawing, so that they are visible even when lots of players crowd some area.  This was a suggestion made in the Bitcointalk thread, and I agree that it is probably useful.
