### PR TITLE
Increase limitfreerelay

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -500,7 +500,7 @@ bool CTransaction::AcceptToMemoryPool(CTxDB& txdb, bool fCheckInputs, bool fLimi
                 nLastTime = nNow;
                 // -limitfreerelay unit is thousand-bytes-per-minute
                 // At default rate it would take over a month to fill 1GB
-                if (dFreeCount > GetArg("-limitfreerelay", 15)*10*1000 && !IsFromMe(*this))
+                if (dFreeCount > GetArg("-limitfreerelay", 60)*10*1000 && !IsFromMe(*this))
                     return error("AcceptToMemoryPool() : free transaction rejected by rate limiter");
                 if (fDebug)
                     printf("Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);


### PR DESCRIPTION
Increase default limit for relaying free tx for 0.25KB/s to 1KB/s (15KB/minute to 60KB/minute).
