### PR TITLE
Show ip in 'version message'

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2360,7 +2360,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
         pfrom->fSuccessfullyConnected = true;
 
-        printf("version message: version %d, blocks=%d\n", pfrom->nVersion, pfrom->nStartingHeight);
+        printf("version message: version %d, blocks=%d, ip=%s\n", pfrom->nVersion, pfrom->nStartingHeight, pfrom->addr.ToString().c_str());
 
         cPeerBlockCounts.input(pfrom->nStartingHeight);
     }


### PR DESCRIPTION
Show the IP of the node and the chain height in the debug.log file.
Allow to reconnect to a specific node you know which chain it is on.

Ex :

```
version message: version 1000500, blocks=94307, ip=178.142.53.74:8398
```
