### PR TITLE
Reduce checks of blkindex blocks.

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -536,7 +536,7 @@ bool CTxDB::LoadBlockIndex()
     CBlockIndex* pindexFork = NULL;
     for (CBlockIndex* pindex = pindexBest; pindex && pindex->pprev; pindex = pindex->pprev)
     {
-        if (pindex->nHeight < nBestHeight-2500 && !mapArgs.count("-checkblocks"))
+        if (pindex->nHeight < nBestHeight-100 && !mapArgs.count("-checkblocks"))
             break;
         CBlock block;
         if (!block.ReadFromDisk(pindex))


### PR DESCRIPTION
Only check the last 100 blocks on startup in LoadBlockIndex instead of
the last 2500 as before.
