### PR TITLE
Upgraded OpenSSL. 

### DIFF
--- a/contrib/easywinbuilder/set_vars.bat
+++ b/contrib/easywinbuilder/set_vars.bat
@@ -4,7 +4,7 @@
 @set LANG=en_US.UTF8
 @set LC_ALL=en_US.UTF8
 
-@set OPENSSL=openssl-1.0.1e
+@set OPENSSL=openssl-1.0.1g
 @set BERKELEYDB=db-4.8.30.NC
 @set BOOST=boost_1_54_0
 @set BOOSTVERSION=1.54.0

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,12 +9,12 @@ MINGW=$(shell uname -s|grep -i mingw32)
 DEFS += -DBOOST_THREAD_USE_LIB
 
 INCLUDEPATHS= \
-	-I../libs/openssl-1.0.1e/include \
+	-I../libs/openssl-1.0.1g/include \
 	-I../libs/db-4.7.25.NC/build_unix \
 	-I../libs/boost_1_50_0
 
 LIBPATHS= \
-	-L../libs/openssl-1.0.1e \
+	-L../libs/openssl-1.0.1g \
 	-L../libs/db-4.7.25.NC/build_unix \
 	-L../libs/boost_1_50_0/stage/lib
 

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -9,12 +9,12 @@ MINGW=$(shell uname -s|grep -i mingw32)
 DEFS += -DBOOST_THREAD_USE_LIB
 
 INCLUDEPATHS?= \
-	-I../libs/openssl-1.0.1e/include \
+	-I../libs/openssl-1.0.1g/include \
 	-I../libs/db-4.7.25.NC/build_unix \
 	-I../libs/boost_1_50_0
 
 LIBPATHS?= \
-	-L../libs/openssl-1.0.1e \
+	-L../libs/openssl-1.0.1g \
 	-L../libs/db-4.7.25.NC/build_unix \
 	-L../libs/boost_1_50_0/stage/lib
 


### PR DESCRIPTION
Mirror the commit for Namecoin, changing OpenSSL version to 1.0.1g in the Windows build scripts.
