### PR TITLE
Fix crash when name_update'ing dead players.

### DIFF
--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -1232,6 +1232,9 @@ Value name_update(const Array& params, bool fHelp)
             throw runtime_error("could not find a coin with this name");
         }
 
+        if (tx.nVersion == GAME_TX_VERSION)
+          throw std::runtime_error ("this player is dead");
+
         uint256 wtxInHash = tx.GetHash();
 
         if (!pwalletMain->mapWallet.count(wtxInHash))


### PR DESCRIPTION
Add an additional check to prevent name_update from being done on dead
players.  This crashed the daemon previously.
