### PR TITLE
Add -dbstats argument.

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -273,6 +273,98 @@ bool CDB::Rewrite(const string& strFile)
     return false;
 }
 
+/* Internal struct to accumulate db stats.  */
+struct DbstatsPerKeyData
+{
+  unsigned count;
+  size_t totalKeySize, totalValueSize;
+  size_t minKeySize, minValueSize;
+  size_t maxKeySize, maxValueSize;
+};
+
+void
+CDB::PrintStorageStats (const std::string& file)
+{
+  CCriticalBlock lock(cs_db);
+  CDB db(file.c_str (), "r");
+
+  /* Iterate over all entries in the database and keep track of how many
+     there are per different "key" (first string of the key) and how
+     large they are.  */
+  typedef std::map<std::string, DbstatsPerKeyData> DataMap;
+  DataMap data;
+
+  Dbc* pcursor = db.GetCursor ();
+  if (!pcursor)
+    {
+      printf ("Error creating cursor.\n");
+      return;
+    }
+
+  while (true)
+    {
+      CDataStream ssKey(SER_DISK, VERSION);
+      CDataStream ssValue(SER_DISK, VERSION);
+      const int ret = db.ReadAtCursor (pcursor, ssKey, ssValue, DB_NEXT);
+      if (ret == DB_NOTFOUND)
+        {
+          pcursor->close ();
+          break;
+        }
+      if (ret != 0)
+        {
+          pcursor->close ();
+          printf ("Error reading at cursor.\n");
+          return;
+        }
+
+      std::string key;
+      ssKey >> key;
+
+      /* Note that size reported will be the size *without* the already
+         read key string.  Should not matter much, as this information
+         is, of course, known anyway.  */
+      const size_t sizeKey = ssKey.size ();
+      const size_t sizeValue = ssValue.size ();
+
+      DataMap::iterator i = data.find (key);
+      if (i == data.end ())
+        {
+          DbstatsPerKeyData dat;
+          dat.count = 1;
+          dat.totalKeySize = dat.minKeySize = dat.maxKeySize = sizeKey;
+          dat.totalValueSize = dat.minValueSize = dat.maxValueSize = sizeValue;
+          data.insert (std::make_pair (key, dat));
+        }
+      else
+        {
+          DbstatsPerKeyData& dat = i->second;
+          assert (dat.count >= 1);
+          ++dat.count;
+
+          dat.totalKeySize += sizeKey;
+          dat.totalValueSize += sizeValue;
+
+          dat.minKeySize = std::min (dat.minKeySize, sizeKey);
+          dat.minValueSize = std::min (dat.minValueSize, sizeValue);
+
+          dat.maxKeySize = std::max (dat.maxKeySize, sizeKey);
+          dat.maxValueSize = std::max (dat.maxValueSize, sizeValue);
+        }
+    }
+
+  printf ("Database stats for '%s' collected:\n", file.c_str ());
+  for (DataMap::const_iterator i = data.begin (); i != data.end (); ++i)
+    {
+      const DbstatsPerKeyData& dat = i->second;
+      printf ("  %s: %u entries\n", i->first.c_str (), dat.count);
+      printf ("    keys:   %u total, %u min, %u max\n",
+              dat.totalKeySize, dat.minKeySize, dat.maxKeySize);
+      printf ("    values: %u total, %u min, %u max\n",
+              dat.totalValueSize, dat.minValueSize, dat.maxValueSize);
+    }
+}
+
 void DBFlush(bool fShutdown)
 {
     // Flush log data to the actual data file

--- a/src/db.h
+++ b/src/db.h
@@ -315,6 +315,14 @@ public:
       Close ();
       Rewrite (strFile);
     }
+
+    /**
+     * Print some storage stats about the database file for debugging
+     * purposes.
+     * @param file Database file to analyse.
+     */
+    static void PrintStorageStats (const std::string& file);
+
 };
 
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -293,6 +293,18 @@ bool AppInit2(int argc, char* argv[])
         return false;
     }
 
+    /* Debugging feature:  Read a BDB database file and print out some
+       statistics about which keys it contains and how much data they
+       use up in the file.  */
+    if (GetBoolArg ("-dbstats"))
+      {
+        const std::string dbfile = GetArg ("-dbstatsfile", "blkindex.dat");
+        printf ("Database storage stats for '%s' requested.\n",
+                dbfile.c_str ());
+        CDB::PrintStorageStats (dbfile);
+        return true;
+      }
+
     //
     // Limit to single instance per user
     // Required to protect the database files if we're going to keep deleting log.*


### PR DESCRIPTION
Implement the -dbstats argument, which runs a database file storage
statistics analysis and prints it to the debug log.
