### PR TITLE
Make address reuse for movements controllable.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -247,6 +247,7 @@ bool AppInit2(int argc, char* argv[])
 
     fNoListen = GetBoolArg("-nolisten");
     fLogTimestamps = GetBoolArg("-logtimestamps");
+    fAddressReuse = !GetBoolArg ("-noaddressreuse");
 
     for (int i = 1; i < argc; i++)
         if (!IsSwitchChar(argv[i][0]))
@@ -680,6 +681,7 @@ std::string HelpMessage()
         "  -rpcallowip=<ip> \t\t  " + _("Allow JSON-RPC connections from specified IP address\n") +
         "  -rpcconnect=<ip> \t  "   + _("Send commands to node running on <ip> (default: 127.0.0.1)\n") +
         "  -keypool=<n>     \t  "   + _("Set key pool size to <n> (default: 100)\n") +
+        "  -noaddressreuse  \t  "   + _("Avoid address reuse for game moves\n") +
         "  -rescan          \t  "   + _("Rescan the block chain for missing wallet transactions\n") +
         "  -algo=<algo>     \t  "   + _("Mining algorithm: sha256d or scrypt. Also affects getdifficulty.\n");
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,6 +29,7 @@ string strMiscWarning;
 bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;
+bool fAddressReuse = true;
 
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -207,6 +207,7 @@ extern std::string strMiscWarning;
 extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
+extern bool fAddressReuse;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();


### PR DESCRIPTION
Add a new "-noaddressreuse" command-line parameter that disables the
reuse of player addresses for movements.  By default, addresses will be
reused to prevent running out of backed up keys.  This patch also
changes the behaviour to send not only the player itself but also the
change to a reused address.

This fixes https://github.com/chronokings/huntercoin/issues/67.

To test it, create a new wallet (preferrably on testnet) with a small keypool (use "-keypool=3" or something), send it some coins and a player and back it up.  If you then perform some moves (say, 10) and restore the backup, everything should still be there.  If you do the same but use "-noaddressreuse", then coins and player should be gone after restoring the backup.  For me it worked on a private testnet that way.  Make also sure that "everything" still works as expected.
