### PR TITLE
Use EraseBadMoveTransactions() for name_clean.

### DIFF
--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -1813,70 +1813,7 @@ Value name_clean(const Array& params, bool fHelp)
     if (fHelp || params.size())
         throw runtime_error("name_clean\nClean unsatisfiable transactions from the wallet - including name_update on an already taken name\n");
 
-    CRITICAL_BLOCK(cs_main)
-    CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
-    {
-        map<uint256, CWalletTx> mapRemove;
-
-        printf("-----------------------------\n");
-
-        {
-            DatabaseSet dbset("r");
-            BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, pwalletMain->mapWallet)
-            {
-                CWalletTx& wtx = item.second;
-                vchType vchName;
-                if (wtx.GetDepthInMainChain () < 1
-                    && IsConflictedTx (dbset, wtx, vchName))
-                {
-                    uint256 hash = wtx.GetHash();
-                    mapRemove[hash] = wtx;
-                }
-            }
-        }
-
-        bool fRepeat = true;
-        while (fRepeat)
-        {
-            fRepeat = false;
-            BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, pwalletMain->mapWallet)
-            {
-                CWalletTx& wtx = item.second;
-                BOOST_FOREACH(const CTxIn& txin, wtx.vin)
-                {
-                    uint256 hash = wtx.GetHash();
-
-                    // If this tx depends on a tx to be removed, remove it too
-                    if (mapRemove.count(txin.prevout.hash) && !mapRemove.count(hash))
-                    {
-                        mapRemove[hash] = wtx;
-                        fRepeat = true;
-                    }
-                }
-            }
-        }
-
-        BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapRemove)
-        {
-            CWalletTx& wtx = item.second;
-
-            UnspendInputs(wtx);
-            wtx.RemoveFromMemoryPool();
-            pwalletMain->EraseFromWallet(wtx.GetHash());
-            vector<unsigned char> vchName;
-            if (GetNameOfTx(wtx, vchName) && mapNamePending.count(vchName))
-            {
-                string name = stringFromVch(vchName);
-                printf("name_clean() : erase %s from pending of name %s", 
-                        wtx.GetHash().GetHex().c_str(), name.c_str());
-                if (!mapNamePending[vchName].erase(wtx.GetHash()))
-                    error("name_clean() : erase but it was not pending");
-            }
-            wtx.print();
-        }
-
-        printf("-----------------------------\n");
-    }
+    EraseBadMoveTransactions ();
 
     return true;
 }


### PR DESCRIPTION
Implement name_clean based on EraseBadMoveTransactions.  This removes code duplication and also cleans transactions that are invalid only by game rules.  (In particular, moves of killed players.)
