### PR TITLE
Implement prune_gamedb RPC command.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -4353,6 +4353,7 @@ void RPCConvertValues(const std::string &strMethod, json_spirit::Array &params)
     if (strMethod == "game_getplayerstate"    && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "game_getpath"           && n > 0) ConvertTo<Array>(params[0]);
     if (strMethod == "game_getpath"           && n > 1) ConvertTo<Array>(params[1]);
+    if (strMethod == "prune_gamedb"           && n > 0) ConvertTo<boost::int64_t>(params[0]);
 }
 
 int CommandLineRPC(int argc, char *argv[])

--- a/src/gamedb.h
+++ b/src/gamedb.h
@@ -36,6 +36,13 @@ const Game::GameState &GetCurrentGameState();
 // no longer valid for the current game state
 void EraseBadMoveTransactions();
 
+/* Prune the game db by removing all states older than the given
+   number of blocks.  Actually, we keep the newest state that is older
+   than the treshold, so that we can integrate forward
+   in time from there and (more or less) efficiently reconstruct
+   every state after the treshold.  */
+void PruneGameDB (unsigned nHeight);
+
 bool UpgradeGameDB();
 
 #endif // GAMEDB_H

--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -1727,6 +1727,23 @@ game_getpath (const Array& params, bool fHelp)
   return res;
 }
 
+Value
+prune_gamedb (const Array& params, bool fHelp)
+{
+  if (fHelp || params.size () != 1)
+    throw runtime_error ("prune_gamedb DEPTH\n"
+                         "Remove old data from the game database.  We keep\n"
+                         "at least the last DEPTH blocks.\n");
+
+  int depth = params[0].get_int ();
+  if (depth > nBestHeight)
+    depth = nBestHeight;
+  if (depth >= 0)
+    PruneGameDB (nBestHeight - depth);
+
+  return true;
+}
+
 void UnspendInputs(CWalletTx& wtx)
 {
     set<CWalletTx*> setCoins;
@@ -2186,6 +2203,7 @@ CHooks* InitHook()
     mapCallTable.insert(make_pair("game_waitforchange", &game_waitforchange));
     mapCallTable.insert(make_pair("game_getplayerstate", &game_getplayerstate));
     mapCallTable.insert(make_pair("game_getpath", &game_getpath));
+    mapCallTable.insert(make_pair("prune_gamedb", &prune_gamedb));
     mapCallTable.insert(make_pair("deletetransaction", &deletetransaction));
     setCallAsync.insert("game_waitforchange");
     hashGenesisBlock = hashHuntercoinGenesisBlock[fTestNet ? 1 : 0];


### PR DESCRIPTION
Add a first (trivial) "appetizer" for pruning:  With this patch, a new RPC command "prune_gamedb" is implemented.  This can be used to remove old entries from game.dat to shrinken it.  The exact usage is like this:

`huntercoind prune_gamedb DEPTH`

DEPTH is the number of blocks to keep.  At least the current state and one before it will always be kept, though, so it is possible to use 0 as DEPTH.

Pruning of the game state should be possible without any risk.  The only consequence is that the game state has to be recalculated (expensive!) when game_getstate is used with an explicit old block number, or a reorganisation is going back beyond the last saved state (unlikely).

Doing `prune_gamedb 5000` brings the size of game.dat down from 200 MiB to less than 1 MiB.  So it is not entirely pointless, although this pruning is, admittedly, the one with the least potential savings.  But it was also the easiest to implement.
