### PR TITLE
Switch Qt UI to new-style name registration.

### DIFF
--- a/src/qt/configurenamedialog1.cpp
+++ b/src/qt/configurenamedialog1.cpp
@@ -22,10 +22,9 @@
 #include <QPushButton>
 #include <QClipboard>
 
-ConfigureNameDialog1::ConfigureNameDialog1(const QString &name_, const std::string &data, const QString &address_, QWidget *parent) :
+ConfigureNameDialog1::ConfigureNameDialog1(const QString &name_, const std::string &data, QWidget *parent) :
     QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint),
     name(name_),
-    address(address_),
     ui(new Ui::ConfigureNameDialog1)
 {
     ui->setupUi(this);
@@ -37,8 +36,6 @@ ConfigureNameDialog1::ConfigureNameDialog1(const QString &name_, const std::stri
     GUIUtil::setupAddressWidget(ui->rewardAddr, this, true);
 
     ui->labelName->setText(GUIUtil::HtmlEscape(name));
-    ui->labelAddress->setText(GUIUtil::HtmlEscape(address));
-    ui->labelAddress->setFont(GUIUtil::bitcoinAddressFont());
 
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 
@@ -150,7 +147,7 @@ void ConfigureNameDialog1::accept()
     QString err_msg;
     try
     {
-        err_msg = walletModel->nameFirstUpdatePrepare(name, returnData, false);
+        err_msg = walletModel->nameRegister(name, returnData);
     }
     catch (std::exception& e) 
     {
@@ -187,11 +184,6 @@ void ConfigureNameDialog1::setModel(WalletModel *walletModel)
     }
     else
         ui->useRewardAddressForNewPlayers->setChecked(walletModel->getOptionsModel()->getDefaultRewardAddress() == ui->rewardAddr->text());
-}
-
-void ConfigureNameDialog1::on_copyButton_clicked()
-{
-    QApplication::clipboard()->setText(address);
 }
 
 void ConfigureNameDialog1::on_pasteButton_clicked()

--- a/src/qt/configurenamedialog1.h
+++ b/src/qt/configurenamedialog1.h
@@ -20,7 +20,7 @@ class ConfigureNameDialog1 : public QDialog
 
 public:
 
-    explicit ConfigureNameDialog1(const QString &name_, const std::string &data, const QString &address_, QWidget *parent = 0);
+    explicit ConfigureNameDialog1(const QString &name_, const std::string &data, QWidget *parent = 0);
     ~ConfigureNameDialog1();
 
     void setModel(WalletModel *walletModel);
@@ -29,7 +29,6 @@ public:
 public slots:
     void accept();
     void reject();
-    void on_copyButton_clicked();
     void on_addressBookButton_clicked();
     void on_pasteButton_clicked();
     void colorButtonToggled(bool checked);
@@ -39,7 +38,7 @@ private:
     std::string returnData;
     Ui::ConfigureNameDialog1 *ui;
     WalletModel *walletModel;
-    QString name, address;
+    QString name;
 
     bool reward_set;
 

--- a/src/qt/forms/configurenamedialog1.ui
+++ b/src/qt/forms/configurenamedialog1.ui
@@ -130,85 +130,16 @@
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="labelCurrentAddress">
-       <property name="text">
-        <string>&amp;Address:</string>
-       </property>
-       <property name="buddy">
-        <cstring>copyButton</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QLabel" name="labelAddress">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Huntercoin address to which the name is assigned</string>
-         </property>
-         <property name="text">
-          <string notr="true">HVguPy1tWgbu9cKy6YGYEJFJ6RD7z7F7MJ</string>
-         </property>
-         <property name="indent">
-          <number>3</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="copyButton">
-         <property name="toolTip">
-          <string>Copy address to clipboard</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../bitcoin.qrc">
-           <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
-         </property>
-         <property name="shortcut">
-          <string>Alt+P</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item row="5" column="0">
       <widget class="QLabel" name="labelRewardAddress">
        <property name="text">
         <string>&amp;Reward address:</string>
        </property>
        <property name="buddy">
-        <cstring>copyButton</cstring>
+        <cstring>rewardAddr</cstring>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="4" column="1">
       <layout class="QHBoxLayout" name="rewardAddrLayout">
        <property name="spacing">
         <number>0</number>
@@ -266,7 +197,7 @@ If empty, player's own address will be used.</string>
        </item>
       </layout>
      </item>
-     <item row="6" column="1">
+     <item row="5" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_4">
        <item>
         <widget class="QLabel" name="label">

--- a/src/qt/nametablemodel.cpp
+++ b/src/qt/nametablemodel.cpp
@@ -17,8 +17,6 @@
 
 #include <QTimer>
 
-extern std::map<std::vector<unsigned char>, PreparedNameFirstUpdate> mapMyNameFirstUpdate;
-
 struct NameTableEntryLessThan
 {
     bool operator()(const NameTableEntry &a, const NameTableEntry &b) const
@@ -88,17 +86,6 @@ public:
             if (!item.second.transferred)
               cachedNameTable.append (item.second);
           }
-
-        // Add pending names (name_new)
-        BOOST_FOREACH(const PAIRTYPE(std::vector<unsigned char>, PreparedNameFirstUpdate)& item, mapMyNameFirstUpdate)
-        {
-            std::string strAddress = "";
-            GetNameAddress(item.second.wtx, strAddress);
-            int nDummyHeight = NameTableEntry::NAME_NEW;
-            if (item.second.fPostponed)
-                nDummyHeight = NameTableEntry::NAME_NEW_POSTPONED;
-            cachedNameTable.append(NameTableEntry(stringFromVch(item.first), stringFromVch(item.second.vchData), strAddress, nDummyHeight));
-        }
 
         // qLowerBound() and qUpperBound() require our cachedNameTable list to be sorted in asc order
         qSort(cachedNameTable.begin(), cachedNameTable.end(), NameTableEntryLessThan());

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -85,28 +85,10 @@ public:
 
     bool nameAvailable(const QString &name);
 
-    struct NameNewReturn
-    {
-         bool ok;
-         QString err_msg;
-         QString address;
-         std::vector<unsigned char> vchName;
-         uint256 hex;   // Transaction hash in hex
-         uint64 rand;   // Secret number in hex
-         uint160 hash;  // Hash of rand+name
-    };
-
     // Register new name
     // Requires unlocked wallet; can throw exception instead of returning error
-    NameNewReturn nameNew(const QString &name);
+    QString nameRegister(const QString &name, const std::string &data);
 
-    // Create pending name update
-    // Requires unlocked wallet; can throw exception instead of returning error
-    QString nameFirstUpdatePrepare(const QString &name, const std::string &data, bool fPostponed = false);
-
-    // Send pending name updates, if they are 2 blocks old
-    void sendPendingNameFirstUpdates();
-    
     // Update name
     // Requires unlocked wallet; can throw exception instead of returning error
     QString nameUpdate(const QString &name, const std::string &data, const QString &transferToAddress);
@@ -164,14 +146,10 @@ private:
     int cachedNumBlocks;
 
     QTimer *pollTimer;
-    bool fSyncedAtLeastOnce;    // For sending automatic name_firstupdate
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
     void checkBalanceChanged();
-
-    std::string nameFirstUpdateCreateTx(CWalletTx &wtx, const std::vector<unsigned char> &vchName, uint256 wtxInHash, uint64 rand, const std::vector<unsigned char> &vchValue, int64 *pnFeeRet = NULL);
-    std::string nameFirstUpdateCreateTx(CWalletTx &wtx, const std::vector<unsigned char> &vchName, CWalletTx &wtxIn, uint64 rand, const std::vector<unsigned char> &vchValue, int64 *pnFeeRet = NULL);
 
 signals:
     // Signal that balance in wallet changed

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1269,28 +1269,6 @@ bool CWallet::DelAddressBookName(const string& strAddress)
     return CWalletDB(strWalletFile).EraseName(strAddress);
 }
 
-#ifdef GUI
-bool CWallet::WriteNameFirstUpdate(const std::vector<unsigned char>& vchName,
-                                   const uint256& hex,
-                                   const uint64& rand,
-                                   bool fPostponed,
-                                   const std::vector<unsigned char>& vchData,
-                                   const CWalletTx &wtx)
-{
-    if (!fFileBacked)
-        return false;
-    return CWalletDB(strWalletFile).WriteNameFirstUpdate(vchName, hex, rand, fPostponed, vchData, wtx);
-}
-
-bool CWallet::EraseNameFirstUpdate(const std::vector<unsigned char>& vchName)
-{
-    if (!fFileBacked)
-        return false;
-    return CWalletDB(strWalletFile).EraseNameFirstUpdate(vchName);
-}
-#endif
-
-
 void CWallet::PrintWallet(const CBlock& block)
 {
     CRITICAL_BLOCK(cs_mapWallet)

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -233,16 +233,6 @@ public:
     // requires cs_mapAddressBook lock
     bool DelAddressBookName(const std::string& strAddress);
     
-#ifdef GUI
-    bool WriteNameFirstUpdate(const std::vector<unsigned char>& vchName,
-                              const uint256& hex,
-                              const uint64& rand,
-                              bool fPostponed,
-                              const std::vector<unsigned char>& vchData,
-                              const CWalletTx &wtx);
-    bool EraseNameFirstUpdate(const std::vector<unsigned char>& vchName);
-#endif
-
     void UpdatedTransaction(const uint256 &hashTx)
     {
 #ifdef GUI
@@ -797,16 +787,5 @@ public:
 };
 
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);
-
-#ifdef GUI
-// Editable transaction, which is not broadcasted immediately (only after 2 blocks)
-struct PreparedNameFirstUpdate
-{
-    uint64 rand;
-    std::vector<unsigned char> vchData;
-    CWalletTx wtx;
-    bool fPostponed;     // Do not send while Configure Name dialog is open
-};
-#endif
 
 #endif

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -63,16 +63,6 @@ public:
         return Write(std::make_pair(std::string("address"), hash160), hash160, false);
     }
     
-#ifdef GUI
-    bool WriteNameFirstUpdate(const std::vector<unsigned char>& vchName,
-                              const uint256& hex,
-                              const uint64& rand,
-                              bool fPostponed,
-                              const std::vector<unsigned char>& vchData,
-                              const CWalletTx &wtx);
-    bool EraseNameFirstUpdate(const std::vector<unsigned char>& vchName);
-#endif
-
     bool WriteCryptedKey(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, bool fEraseUnencryptedKey = true)
     {
         nWalletDBUpdated++;


### PR DESCRIPTION
Change the Qt UI code to use immediate name registration (without name_new).  This allows us to remove all the "prepare name_firstupdate" stuff that was there, greatly simplifying the code in general.

Please test carefully.  Note that there shouldn't be any prepared name_firstupdates in the wallet when upgrading to this new version.  Wait until all are sent & confirmed.