### PR TITLE
Fix reorg of OP_RETURN outputs.

### DIFF
--- a/huntercoin-qt.pro
+++ b/huntercoin-qt.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 TARGET = huntercoin-qt
 macx:TARGET = "HunterCoin-Qt"
-VERSION = 1.1.0
+VERSION = 1.1.1
 INCLUDEPATH += src src/json src/qt
 QT += network
 DEFINES += GUI QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -1029,7 +1029,9 @@ CUtxoDB::RemoveUtxo (const CTransaction& tx)
   for (unsigned n = 0; n < tx.vout.size (); ++n)
     {
       COutPoint pos(hash, n);
-      if (!RemoveUtxo (pos))
+      if (tx.vout[n].IsUnspendable ())
+        assert (!Exists (GetKey (pos)));
+      else if (!RemoveUtxo (pos))
         return false;
     }
 

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -4,7 +4,7 @@ IDI_ICON1 ICON DISCARDABLE "icons/huntercoin.ico"
 
 #define CLIENT_VERSION_MAJOR 1
 #define CLIENT_VERSION_MINOR 1
-#define CLIENT_VERSION_REVISION 0
+#define CLIENT_VERSION_REVISION 1
 #define CLIENT_VERSION_BUILD 0
 
 // Converts the parameter X to a string after macro replacement on X has been performed.

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -35,7 +35,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int VERSION = 1010000;
+static const int VERSION = 1010100;
 static const char* pszSubVer = "";
 static const bool VERSION_IS_BETA = false;
 


### PR DESCRIPTION
OP_RETURN outputs are not part of the UTXO set.  This caused reorgs
to fail, when the client attempted to remove the outputs of an undone
transaction from the UTXO set.  Fix this by checking for unspendability
and only removing spendable outputs.