### PR TITLE
Implement proposed changes for next hardfork.

### DIFF
--- a/huntercoin-qt.pro
+++ b/huntercoin-qt.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 TARGET = huntercoin-qt
 macx:TARGET = "HunterCoin-Qt"
-VERSION = 1.1.1
+VERSION = 1.2.0
 INCLUDEPATH += src src/json src/qt
 QT += network
 DEFINES += GUI QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -989,10 +989,6 @@ Value sendtoaddress(const Array& params, bool fHelp)
 
         if (params.size () >= 5)
           {
-            /* TODO: Remove after hardfork.  */
-            if (!ForkInEffect (FORK_CARRYINGCAP, nBestHeight))
-              throw std::runtime_error ("tagging is not yet available");
-
             const std::string tagString = params[4].get_str ();
             if (tagString.size () > OPRETURN_MAX_STRLEN)
               throw JSONRPCError (RPC_INVALID_PARAMETER,

--- a/src/gamestate.cpp
+++ b/src/gamestate.cpp
@@ -688,7 +688,7 @@ GameState::GameState()
 {
     crownPos.x = CROWN_START_X;
     crownPos.y = CROWN_START_Y;
-    lostCoins = 0;
+    gameFund = 0;
     nHeight = -1;
     nDisasterHeight = -1;
     hashBlock = 0;
@@ -757,7 +757,7 @@ json_spirit::Value GameState::ToJsonValue() const
     }
     obj.push_back(Pair("crown", subobj));
 
-    obj.push_back (Pair("lostCoins", ValueFromAmount (lostCoins)));
+    obj.push_back (Pair("gameFund", ValueFromAmount (gameFund)));
     obj.push_back (Pair("height", nHeight));
     obj.push_back (Pair("disasterHeight", nDisasterHeight));
     obj.push_back (Pair("hashBlock", hashBlock.ToString().c_str()));
@@ -965,13 +965,13 @@ GameState::CrownBonus (int64 nAmount)
                                              true);
       const int64 rem = ch.CollectLoot (loot, nHeight, cap);
 
-      /* We keep to the logic of "crown on the floor -> coins lost" and
+      /* We keep to the logic of "crown on the floor -> game fund" and
          don't distribute coins that can not be hold by the crown holder
          due to carrying capacity to the map.  */
-      lostCoins += rem;
+      gameFund += rem;
     }
   else
-    lostCoins += nAmount;
+    gameFund += nAmount;
 }
 
 unsigned

--- a/src/gamestate.cpp
+++ b/src/gamestate.cpp
@@ -1215,7 +1215,7 @@ GameState::KillSpawnArea (StepResult& step)
 }
 
 void
-GameState::ApplyPoison (RandomGenerator& rng)
+GameState::ApplyDisaster (RandomGenerator& rng)
 {
   /* Set random life expectations for every player on the map.  */
   BOOST_FOREACH(PAIRTYPE(const PlayerID, PlayerState)& p, players)
@@ -1228,6 +1228,10 @@ GameState::ApplyPoison (RandomGenerator& rng)
 
       p.second.remainingLife = rng.GetIntRnd (POISON_MIN_LIFE, POISON_MAX_LIFE);
     }
+
+  /* Remove all hearts from the map.  */
+  if (ForkInEffect (FORK_LESSHEARTS, nHeight))
+    hearts.clear ();
 
   /* Reset disaster counter.  */
   nDisasterHeight = nHeight;
@@ -1454,8 +1458,8 @@ bool Game::PerformStep(const GameState &inState, const StepData &stepData, GameS
     const bool isDisaster = outState.CheckForDisaster (rnd);
     if (isDisaster)
       {
-        printf ("POISON DISASTER @%d!\n", outState.nHeight);
-        outState.ApplyPoison (rnd);
+        printf ("DISASTER @%d!\n", outState.nHeight);
+        outState.ApplyDisaster (rnd);
         assert (outState.nHeight == outState.nDisasterHeight);
       }
 

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -354,8 +354,8 @@ struct GameState
     Coord crownPos;
     CharacterID crownHolder;
 
-    /* Amount of coins lost due to the crown being on the ground.  */
-    int64 lostCoins;
+    /* Amount of coins in the "game fund" pool.  */
+    int64 gameFund;
 
     // Number of steps since the game start.
     // State with nHeight==i includes moves from i-th block
@@ -392,7 +392,7 @@ struct GameState
       READWRITE(crownHolder.player);
       if (!crownHolder.player.empty())
         READWRITE(crownHolder.index);
-      READWRITE(lostCoins);
+      READWRITE(gameFund);
 
       READWRITE(nHeight);
       READWRITE(nDisasterHeight);

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -14,11 +14,8 @@ namespace Game
 static const int NUM_TEAM_COLORS = 4;
 static const int MAX_WAYPOINTS = 100;                      // Maximum number of waypoints per character
 static const unsigned char MAX_STAY_IN_SPAWN_AREA = 30;
-static const int DESTRUCT_RADIUS = 1;
-static const int DESTRUCT_RADIUS_MAIN = 2;                 // Destruction radius for main character
 static const int MAX_CHARACTERS_PER_PLAYER = 20;           // Maximum number of characters per player at the same time
 static const int MAX_CHARACTERS_PER_PLAYER_TOTAL = 1000;   // Maximum number of characters per player in the lifetime
-static const int HEART_EVERY_NTH_BLOCK = 10;               // Spawn rate of hearts
 
 // Unique player name
 typedef std::string PlayerID;

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -399,7 +399,7 @@ struct GameState
     void KillSpawnArea (StepResult& step);
 
     /* Apply poison disaster to the state.  */
-    void ApplyPoison (RandomGenerator& rng);
+    void ApplyDisaster (RandomGenerator& rng);
     /* Decrement poison life expectation and kill players whose has
        dropped to zero.  */
     void DecrementLife (StepResult& step);

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -419,6 +419,12 @@ struct GameState
      */
     unsigned GetNumInitialCharacters () const;
 
+    /* Handle loot of a killed character.  Depending on the circumstances,
+       it may be dropped (with or without miner tax), refunded in a bounty
+       transaction or added to the game fund.  */
+    void HandleKilledLoot (const PlayerID& pId, int chInd,
+                           bool hasTax, bool canRefund, StepResult& step);
+
     /* For a given list of killed players, kill all their characters
        and collect the tax amount.  The killed players are removed from
        the state's list of players.  */

--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -2457,9 +2457,8 @@ CHuntercoinHooks::ConnectInputs (DatabaseSet& dbset,
 
     if (tx.nVersion != NAMECOIN_TX_VERSION)
     {
-        /* See if there are any name outputs.  If they are, disallow
-           for mempool or after the corresponding soft fork point.  Note
-           that we can't just use 'DecodeNameTx', since that would also
+        /* See if there are any name outputs.  If they are, disallow that.
+           Note that we can't just use 'DecodeNameTx', since that would also
            report "false" if we have *multiple* name outputs.  This should
            also be detected, though.  */
         bool foundOuts = false;
@@ -2474,12 +2473,11 @@ CHuntercoinHooks::ConnectInputs (DatabaseSet& dbset,
                 foundOuts = true;
         }
 
-        /* TODO: After the softfork, check if we can enforce this
-           check without height condition at all.  Possibly no conflicting
-           tx are in the chain?  */
+        /* While this was introduced with FORK_CARRYINGCAP, no offending
+           tx is in the chain before.  Thus we can enforce the check
+           unconditionally for simplicity.  */
         if (foundOuts)
-          if (!fBlock || ForkInEffect (FORK_CARRYINGCAP, pindexBlock->nHeight))
-            return error("ConnectInputHook: non-Namecoin tx has name outputs");
+          return error ("ConnectInputHook: non-Namecoin tx has name outputs");
 
         // Make sure name-op outputs are not spent by a regular transaction, or the name
         // would be lost

--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -1943,7 +1943,7 @@ analyseutxo (const Array& params, bool fHelp)
      money supply and can check it.  */
   const Game::GameState& state = GetCurrentGameState ();
   const int64 onMap = state.GetCoinsOnMap ();
-  const int64 lostCoins = state.lostCoins;
+  const int64 gameFund = state.gameFund;
   const int64 rewards = pindexBest->GetTotalRewards ();
 
   /* Construct the result.  */
@@ -1953,21 +1953,22 @@ analyseutxo (const Array& params, bool fHelp)
   res.push_back (Pair ("num_utxo", static_cast<int> (txoCnt)));
 
   Object subobj;
+  const int64_t supply = amount + onMap + gameFund;
   subobj.push_back (Pair ("utxo", ValueFromAmount (amount)));
   subobj.push_back (Pair ("map", ValueFromAmount (onMap)));
-  subobj.push_back (Pair ("total", ValueFromAmount (amount + onMap)));
+  subobj.push_back (Pair ("gameFund", ValueFromAmount (gameFund)));
+  subobj.push_back (Pair ("total", ValueFromAmount (supply)));
   res.push_back (Pair ("moneysupply", subobj));
 
   subobj.clear ();
-  const int64_t expected = rewards - lostCoins - dupCoinbase - unspendable;
+  const int64_t expected = rewards - dupCoinbase - unspendable;
   subobj.push_back (Pair ("rewards", ValueFromAmount (rewards)));
-  subobj.push_back (Pair ("lost", ValueFromAmount (lostCoins)));
   subobj.push_back (Pair ("dup_coinbase", ValueFromAmount (dupCoinbase)));
   subobj.push_back (Pair ("unspendable", ValueFromAmount (unspendable)));
   subobj.push_back (Pair ("total", ValueFromAmount (expected)));
   res.push_back (Pair ("expected", subobj));
 
-  res.push_back (Pair ("check", amount + onMap == expected));
+  res.push_back (Pair ("check", supply == expected));
 
   return res;
 }

--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -233,7 +233,11 @@ GetNameCoinAmount (unsigned nHeight, bool frontEnd)
   if (frontEnd)
     nHeight += 10;
 
-  return ForkInEffect (FORK_POISON, nHeight) ? 10 * COIN : COIN;
+  if (ForkInEffect (FORK_LESSHEARTS, nHeight))
+    return 200 * COIN;
+  if (ForkInEffect (FORK_POISON, nHeight))
+    return 10 * COIN;
+  return COIN;
 }
 
 bool

--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -713,7 +713,7 @@ Value name_list(const Array& params, bool fHelp)
 
 Value name_debug(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 0)
+    if (fHelp || params.size () != 0)
         throw runtime_error(
             "name_debug\n"
             "Dump pending transactions id in the debug file.\n");
@@ -2431,7 +2431,6 @@ CHuntercoinHooks::ConnectInputs (DatabaseSet& dbset,
        a non-game transaction.  */
     assert (vTxoPrev.size () == tx.vin.size ());
 
-    int nInput;
     bool found = false;
 
     int prevHeight, prevOp;
@@ -2449,7 +2448,6 @@ CHuntercoinHooks::ConnectInputs (DatabaseSet& dbset,
             if (found)
                 return error("ConnectInputHook() : multiple previous name transactions");
             found = true;
-            nInput = i;
             vvchPrevArgs = vvchPrevArgsRead;
             prevCoinAmount = out.nValue;
             prevHeight = vTxoPrev[i].height;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1753,15 +1753,14 @@ bool CBlock::CheckProofOfWork(int nHeight) const
 
         if (auxpow.get() != NULL)
         {
-            /* Disallow auxpow parent blocks that have an auxpow themselves.  */
-            /* TODO: Can possibly be removed and the check made unconditional
-               after the fork is carried out.  */
-            if (ForkInEffect (FORK_CARRYINGCAP, nHeight)
-                && (auxpow->parentBlock.nVersion & BLOCK_VERSION_AUXPOW))
+            /* Disallow auxpow parent blocks that have an auxpow themselves.
+               While this was introduced with a fork, no such tx are present
+               in the chain before the fork point.  Thus it can be enforced
+               throughout the chain without checking for FORK_CARRYINGCAP.  */
+            if (auxpow->parentBlock.nVersion & BLOCK_VERSION_AUXPOW)
               return error ("%s : auxpow parent block has auxpow version",
                             __func__);
-            assert (!ForkInEffect (FORK_CARRYINGCAP, nHeight)
-                    || !auxpow->parentBlock.auxpow);
+            assert (!auxpow->parentBlock.auxpow);
 
             if (auxpow->algo != algo)
                 return error("CheckProofOfWork() : AUX POW uses different algorithm");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,6 +94,10 @@ ForkInEffect (Fork type, unsigned nHeight)
     case FORK_CARRYINGCAP:
       return nHeight >= (fTestNet ? 200000 : 500000);
 
+    case FORK_LESSHEARTS:
+      /* FIXME: Set actual heights.  */
+      return false;
+
     default:
       assert (false);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,8 +95,7 @@ ForkInEffect (Fork type, unsigned nHeight)
       return nHeight >= (fTestNet ? 200000 : 500000);
 
     case FORK_LESSHEARTS:
-      /* FIXME: Set actual heights.  */
-      return false;
+      return nHeight >= (fTestNet ? 240000 : 590000);
 
     default:
       assert (false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,12 +257,6 @@ CTxOut::IsStandard () const
   std::string tag;
   if (scriptPubKey.GetTag (tag))
     {
-      /* TODO: Remove after hardfork.  This is just here to prevent
-         such tx from being created before all nodes have logic to remove
-         them from the UTXO set.  */
-      if (!ForkInEffect (FORK_CARRYINGCAP, nBestHeight))
-        return error ("%s: tagging not yet available", __func__);
-
       if (tag.size () > OPRETURN_MAX_STRLEN)
         return error ("%s: too long tag string", __func__);
       if (nValue < OPRETURN_MIN_LOCKED)

--- a/src/main.h
+++ b/src/main.h
@@ -102,6 +102,7 @@ extern int fUseUPnP;
    and mainnet, or for a "testing mode".  */
 enum Fork
 {
+
   /* Poison disaster, increased general cost 1 HUC -> 10 HUC, just general
      as initial character.  */
   FORK_POISON,
@@ -110,6 +111,12 @@ enum Fork
      new-style name registration, stricter rule checks for transaction
      version and auxpow (in parallel to Namecoin).  */
   FORK_CARRYINGCAP,
+
+  /* Update parameters (general 10 HUC -> 200 HUC, carrying capacity increased
+     to 2000 HUC, heart spawn rate reduced to 1/500, general explosion
+     radius only 1).  */
+  FORK_LESSHEARTS,
+
 };
 bool ForkInEffect (Fork type, unsigned nHeight);
 

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -3,8 +3,8 @@ IDI_ICON1 ICON DISCARDABLE "icons/huntercoin.ico"
 #include <windows.h>             // needed for VERSIONINFO
 
 #define CLIENT_VERSION_MAJOR 1
-#define CLIENT_VERSION_MINOR 1
-#define CLIENT_VERSION_REVISION 1
+#define CLIENT_VERSION_MINOR 2
+#define CLIENT_VERSION_REVISION 0
 #define CLIENT_VERSION_BUILD 0
 
 // Converts the parameter X to a string after macro replacement on X has been performed.

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -35,7 +35,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int VERSION = 1010100;
+static const int VERSION = 1020000;
 static const char* pszSubVer = "";
 static const bool VERSION_IS_BETA = false;
 


### PR DESCRIPTION
This implements the changes proposed in http://forum.huntercoin.org/index.php/topic,735.0.html for a future hardfork (currently no height set, needs to be done together with bumping the version before the fork can actually take place).  It also includes some code clean-up.  The changes:

*) Cost of a general is increased from 10 HUC to 200 HUC.
*) Carrying-capacity is increased from 25/50 HUC to 2000 HUC (for both hunters and generals).  The crown holder stays unlimited.
*) Hearts spawn now on every 500th block instead of every 10th.
*) Destruct radius is one square also for generals (reduced from two).
*) At a disaster, all hearts are removed from the map.
*) When someone dies that is poisoned (even if the cause of death is something else) no coins are dropped.  Instead all loot (including the general cost) is added to the "game fund".
*) Death after 30 blocks in the spawn area is reintroduced.  When your general dies that way, you get the full 200 HUC cost refunded as if it was banked.  (Unless you are poisoned - in that case, the point above applies and the coins are added to the game fund instead.)  If a hunter dies, everything is as it was before the previous hardfork.

Please test carefully, although everything seems to work in my own tests.  I've also started a full resync from scratch on my VPS, but that will probably take some time.