### PR TITLE
Decode gametx input scripts to JSON.

### DIFF
--- a/src/gametx.h
+++ b/src/gametx.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include <string>
 
+#include "json/json_spirit.h"
+
 // This module manages transactions for in-game events (e.g. player rewards):
 // - creates transactions for StepResult
 // - parses these transactions and creates string representation (to show in the transaction list)
@@ -33,5 +35,8 @@ bool IsPlayerDeathInput (const CTxIn& in, std::vector<unsigned char>& name);
 // By providing nameStart/EndTag you can make player names bold in HTML.
 // In brief mode details are omitted and fUseColon is ignored
 std::string GetGameTxDescription(const CScript &scriptSig, bool fBrief, const char *nameStartTag = "", const char *nameEndTag = "", bool fUseColon = true);
+
+/* Decode a game tx scriptsig into a JSON object.  */
+void GameInputToJSON (const CScript& scriptSig, json_spirit::Object& o);
 
 #endif // GAMETX_H


### PR DESCRIPTION
When using JSON decode of a game transaction, add some decoded info for game tx inputs.  Also fix a bug with the Qt display of banking for index > 16.

See http://forum.huntercoin.org/index.php/topic,916.0.html.

Note that this just decodes what is in the blockchain.  In particular, if a player died for multiple reasons at once, the one reported will be the first one applicable from the order:

1) Killed by a destruct (self-destruct or attack).
2) Killed for staying too long in the spawn area.
3) Killed by poison.

(This order is defined in gametx.cpp by `CreateGameTransactions` and a consensus parameter.)