### PR TITLE
Fix lock order for name_pending.

### DIFF
--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -1464,8 +1464,8 @@ name_pending (const Array& params, bool fHelp)
 
   Array res;
 
-  CRITICAL_BLOCK (cs_mapTransactions)
   CRITICAL_BLOCK (cs_main)
+  CRITICAL_BLOCK (cs_mapTransactions)
     {
       std::map<vchType, std::set<uint256> >::const_iterator i;
       for (i = mapNamePending.begin (); i != mapNamePending.end (); ++i)


### PR DESCRIPTION
This hopefully prevents deadlocks from happening.  The lock order now matches that during blockchain processing.

Not tested, please verify that it does, indeed, fix the issues.