### PR TITLE
Fix lifesteal and reset fork on testnet

### DIFF
--- a/GameLogicChanges.txt
+++ b/GameLogicChanges.txt
@@ -32,11 +32,11 @@ Life-Steal Fork:
      instead.  The same is true if the "rightful owner" (attacker) has died
      itself.
 
-*) Spawning of characters (and their initial direction) is now random
-   among all walkable tiles.
+* Spawning of characters (and their initial direction) is now random
+  among all walkable tiles.
 
-*) Banks are no longer at the corners, but instead randomly placed.
-   At the fork height, 50 banks are placed with a random life time
-   between 25 and 100 blocks.  Whenever the life time of a bank
-   runs out, it is randomly re-created on a fresh walkable tile
-   and with a fresh life time.
+* Banks are no longer at the corners, but instead randomly placed.
+  At the fork height, 50 banks are placed with a random life time
+  between 25 and 100 blocks.  Whenever the life time of a bank
+  runs out, it is randomly re-created on a fresh walkable tile
+  and with a fresh life time.

--- a/GameLogicChanges.txt
+++ b/GameLogicChanges.txt
@@ -36,7 +36,7 @@ Life-Steal Fork:
   among all walkable tiles.
 
 * Banks are no longer at the corners, but instead randomly placed.
-  At the fork height, 50 banks are placed with a random life time
+  At the fork height, 75 banks are placed with a random life time
   between 25 and 100 blocks.  Whenever the life time of a bank
   runs out, it is randomly re-created on a fresh walkable tile
   and with a fresh life time.

--- a/huntercoin-qt.pro
+++ b/huntercoin-qt.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 TARGET = huntercoin-qt
 macx:TARGET = "HunterCoin-Qt"
-VERSION = 1.3.0
+VERSION = 1.3.0.99
 INCLUDEPATH += src src/json src/qt
 QT += network
 DEFINES += GUI QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1872,6 +1872,30 @@ verifyutxo (const Array& params, bool fHelp)
   return db.Verify ();
 }
 
+Value
+getoutpoints (const Array& params, bool fHelp)
+{
+  if (fHelp || params.size () != 0)
+    throw runtime_error ("getoutpoints\n"
+                         "Get list of all UTXO outpoints.\n");
+
+  CUtxoDB db("r");
+  CUtxoDB::OutPointSet outPoints;
+  if (!db.GetUtxoSet (outPoints))
+    return false;
+
+  Array res;
+  BOOST_FOREACH(const COutPoint& out, outPoints)
+    {
+      Object obj;
+      obj.push_back (Pair ("txid", out.hash.GetHex ()));
+      obj.push_back (Pair ("n", static_cast<int> (out.n)));
+      res.push_back (obj);
+    }
+
+  return res;
+}
+
 Value gettransaction(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
@@ -3695,6 +3719,7 @@ pair<string, rpcfn_type> pCallTable[] =
     make_pair("listaddressgroupings",  &listaddressgroupings),
     make_pair("listsinceblock",        &listsinceblock),
     make_pair("verifyutxo",            &verifyutxo),
+    make_pair("getoutpoints",          &getoutpoints),
     make_pair("getrawtransaction",     &getrawtransaction),
     make_pair("createrawtransaction",  &createrawtransaction),
     make_pair("decoderawtransaction",  &decoderawtransaction),

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -1316,6 +1316,15 @@ CUtxoDB::Analyse (unsigned& nUtxo, int64_t& amount, int64_t& inNames)
   return true;
 }
 
+bool
+CUtxoDB::GetUtxoSet (OutPointSet& res)
+{
+  CCriticalBlock lock(cs_main);
+
+  res.clear ();
+  return InternalRescan (true, &res);
+}
+
 /* ************************************************************************** */
 
 //

--- a/src/db.h
+++ b/src/db.h
@@ -465,15 +465,16 @@ class CUtxoDB : public CDB
 {
 public:
     CUtxoDB(const char* pszMode="r+") : CDB("utxo.dat", pszMode) { }
+
+    /** Set of COutPoints as used in the DB verification.  */
+    typedef std::set<COutPoint> OutPointSet;
+
 private:
     CUtxoDB(const CUtxoDB&);
     void operator=(const CUtxoDB&);
 
     /** Type used as key into the DB.  */
     typedef std::pair<std::string, COutPoint> KeyType;
-
-    /** Set of COutPoints as used in the DB verification.  */
-    typedef std::set<COutPoint> OutPointSet;
 
     /* Construct the look-up key for a given COutPoint.  This just prepends
        the key-string "txo" to it.  */
@@ -514,6 +515,9 @@ public:
     /* Read all entries to analyse the total money supply as well as
        the number of entries.  */
     bool Analyse (unsigned& nUtxo, int64_t& amount, int64_t& inNames);
+
+    /* Return UTXO set.  */
+    bool GetUtxoSet (OutPointSet& res);
 };
 
 

--- a/src/gamedb.cpp
+++ b/src/gamedb.cpp
@@ -636,6 +636,11 @@ extern CWallet* pwalletMain;
 // valid for the current game state (e.g. attack on some player who's already killed)
 void EraseBadMoveTransactions()
 {
+    /* If we do not have a wallet yet, nothing to do.  This can happen
+       with a completely fresh initialisation.  */
+    if (!pwalletMain)
+        return;
+
     CRITICAL_BLOCK(cs_main)
     CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
     {

--- a/src/gamestate.cpp
+++ b/src/gamestate.cpp
@@ -26,7 +26,7 @@ static const unsigned POISON_MIN_LIFE = 1;
 static const unsigned POISON_MAX_LIFE = 50;
 
 /* Parameters for dynamic banks after the life-steal fork.  */
-static const unsigned DYNBANKS_NUM_BANKS = 50;
+static const unsigned DYNBANKS_NUM_BANKS = 75;
 static const unsigned DYNBANKS_MIN_LIFE = 25;
 static const unsigned DYNBANKS_MAX_LIFE = 100;
 

--- a/src/gamestate.cpp
+++ b/src/gamestate.cpp
@@ -209,7 +209,7 @@ KilledByInfo::DropCoins (unsigned nHeight, const PlayerState& victim) const
 }
 
 bool
-KilledByInfo::CanRefund (unsigned nHeight) const
+KilledByInfo::CanRefund (unsigned nHeight, const PlayerState& victim) const
 {
   if (!ForkInEffect (FORK_LESSHEARTS, nHeight))
     return false;
@@ -217,6 +217,11 @@ KilledByInfo::CanRefund (unsigned nHeight) const
   switch (reason)
     {
     case KILLED_SPAWN:
+
+      /* Before life-steal fork, poisoned players were not refunded.  */
+      if (!ForkInEffect (FORK_LIFESTEAL, nHeight) && victim.remainingLife >= 0)
+        return false;
+
       return true;
 
     case KILLED_POISON:
@@ -1677,7 +1682,7 @@ GameState::HandleKilledLoot (const PlayerID& pId, int chInd,
   /* If refunding is possible, do this for the locked amount right now.
      Later on, exclude the amount from further considerations.  */
   bool refunded = false;
-  if (chInd == 0 && info.CanRefund (nHeight))
+  if (chInd == 0 && info.CanRefund (nHeight, pc))
     {
       CollectedLootInfo loot;
       loot.SetRefund (pc.value, nHeight);

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -666,7 +666,7 @@ struct KilledByInfo
   /* See if this killing allows a refund of the general cost to the player.
      This depends on the height, since poison death refunds only after
      the life-steal fork.  */
-  bool CanRefund (unsigned nHeight) const;
+  bool CanRefund (unsigned nHeight, const PlayerState& victim) const;
 
   /* Comparison necessary for STL containers.  */
 

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -164,8 +164,11 @@ struct AttackableCharacter
   /** The character's colour.  */
   unsigned char color;
 
-  /** The initial (before all attacks in the current step) value.  */
-  int64_t value;
+  /**
+   * Amount of coins already drawn from the attacked character's life.
+   * This is the value that can be redistributed to the attackers.
+   */
+  int64_t drawnLife;
 
   /** All attackers that hit it.  */
   std::set<CharacterID> attackers;
@@ -222,12 +225,12 @@ struct CharactersOnTiles
   void ApplyAttacks (const GameState& state, const std::vector<Move>& moves);
 
   /**
-   * Kill characters with too many attackers.  This handles both the
-   * pre- and post-life-steal logic.
+   * Deduct life from attached characters.  This also handles killing
+   * of those with too many attackers, including pre-life-steal.
    * @param state The game state, will be modified.
    * @param result The step result object to fill in.
    */
-  void KillAttacked (GameState& state, StepResult& result) const;
+  void DrawLife (GameState& state, StepResult& result);
 
   /**
    * Remove mutual attacks from the attacker arrays.
@@ -236,12 +239,12 @@ struct CharactersOnTiles
   void DefendMutualAttacks (const GameState& state);
 
   /**
-   * Transfer life from victim to attackers.  If there are more attackers than
+   * Give drawn life back to attackers.  If there are more attackers than
    * available coins, distribute randomly.
    * @param rnd The RNG to use.
    * @param state The state to update.
    */
-  void TransferLife (RandomGenerator& rnd, GameState& state) const;
+  void DistributeDrawnLife (RandomGenerator& rnd, GameState& state) const;
 
 };
 

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -254,14 +254,14 @@ inline int distLInf(const Coord &c1, const Coord &c2)
 
 struct LootInfo
 {
-    int64 nAmount;
+    int64_t nAmount;
     // Time span over the which this loot accumulated
     // This is merely for informative purposes, plus to make
     // hash of the loot tx unique
     int firstBlock, lastBlock;
 
     LootInfo() : nAmount(0), firstBlock(-1), lastBlock(-1) { }
-    LootInfo(int64 nAmount_, int nHeight) : nAmount(nAmount_), firstBlock(nHeight), lastBlock(nHeight) { }
+    LootInfo(int64_t nAmount_, int nHeight) : nAmount(nAmount_), firstBlock(nHeight), lastBlock(nHeight) { }
 
     IMPLEMENT_SERIALIZE
     (
@@ -304,7 +304,7 @@ struct CollectedLootInfo : public LootInfo
        the spawn area, and encoded differently in the game transactions.
        The block height is present to make the resulting tx unique.  */
     inline void
-    SetRefund (int64 refundAmount, int nHeight)
+    SetRefund (int64_t refundAmount, int nHeight)
     {
       assert (nAmount == 0);
       assert (collectedFirstBlock == -1 && collectedLastBlock == -1);
@@ -386,7 +386,7 @@ struct CharacterState
     /* Collect loot by this character.  This takes the carrying capacity
        into account and only collects until this limit is reached.  All
        loot amount that *remains* will be returned.  */
-    int64 CollectLoot (LootInfo newLoot, int nHeight, int64 carryCap);
+    int64_t CollectLoot (LootInfo newLoot, int nHeight, int64_t carryCap);
 
     json_spirit::Value ToJsonValue(bool has_crown) const;
 };
@@ -479,7 +479,7 @@ struct GameState
     CharacterID crownHolder;
 
     /* Amount of coins in the "game fund" pool.  */
-    int64 gameFund;
+    int64_t gameFund;
 
     // Number of steps since the game start.
     // State with nHeight==i includes moves from i-th block
@@ -537,12 +537,12 @@ struct GameState
     json_spirit::Value ToJsonValue() const;
 
     // Helper functions
-    void AddLoot(Coord coord, int64 nAmount);
+    void AddLoot(Coord coord, int64_t nAmount);
     void DivideLootAmongPlayers();
     void CollectHearts(RandomGenerator &rnd);
     void UpdateCrownState(bool &respawn_crown);
     void CollectCrown(RandomGenerator &rnd, bool respawn_crown);
-    void CrownBonus(int64 nAmount);
+    void CrownBonus(int64_t nAmount);
 
     /**
      * Get the number of initial characters for players created in this
@@ -598,7 +598,7 @@ struct GameState
 
 struct StepData : boost::noncopyable
 {
-    int64 nTreasureAmount;
+    int64_t nTreasureAmount;
     uint256 newHash;
     std::vector<Move> vMoves;
 };
@@ -716,7 +716,7 @@ public:
 
     std::vector<CollectedBounty> bounties;
 
-    int64 nTaxAmount;
+    int64_t nTaxAmount;
 
     StepResult() : nTaxAmount(0) { }
 

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -661,7 +661,7 @@ struct KilledByInfo
 
   /* See if this killing should drop the coins.  Otherwise (e. g., for poison)
      the coins are added to the game fund.  */
-  bool DropCoins (unsigned nHeight) const;
+  bool DropCoins (unsigned nHeight, const PlayerState& victim) const;
 
   /* See if this killing allows a refund of the general cost to the player.
      This depends on the height, since poison death refunds only after

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,7 @@ ForkInEffect (Fork type, unsigned nHeight)
       return nHeight >= (fTestNet ? 240000 : 590000);
 
     case FORK_LIFESTEAL:
-      return nHeight >= (fTestNet ? 320000 : 775000);
+      return nHeight >= (fTestNet ? 301000 : 1000000);
 
     default:
       assert (false);

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -5,7 +5,7 @@ IDI_ICON1 ICON DISCARDABLE "icons/huntercoin.ico"
 #define CLIENT_VERSION_MAJOR 1
 #define CLIENT_VERSION_MINOR 3
 #define CLIENT_VERSION_REVISION 0
-#define CLIENT_VERSION_BUILD 0
+#define CLIENT_VERSION_BUILD 99
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -37,7 +37,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int VERSION = 1030000;
+static const int VERSION = 1030099;
 static const char* pszSubVer = "";
 static const bool VERSION_IS_BETA = false;
 


### PR DESCRIPTION
This fixes the issues discovered with the "life steal" fork.  It also resets the fork height for testnet to 301k.  The fork on mainnet is not yet enabled (i. e., height set to 1000k) and can be set once testing is successful.