### PR TITLE
Remove some now-redundant checks after the passed fork.

### DIFF
--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -18,7 +18,7 @@ void RemoveMergedMiningHeader(vector<unsigned char>& vchAux)
     vchAux.erase(vchAux.begin(), vchAux.begin() + sizeof(pchMergedMiningHeader));
 }
 
-bool CAuxPow::Check(uint256 hashAuxBlock, int nChainID, int nHeight)
+bool CAuxPow::Check(uint256 hashAuxBlock, int nChainID)
 {
     if (nIndex != 0)
         return error("AuxPow is not a generate");
@@ -48,10 +48,6 @@ bool CAuxPow::Check(uint256 hashAuxBlock, int nChainID, int nHeight)
 
     CScript::const_iterator pc =
         std::search(script.begin(), script.end(), vchRootHash.begin(), vchRootHash.end());
-
-    /* FIXME: Remove these lines completely once the fork has passed.  */
-    if (!ForkInEffect(FORK_LIFESTEAL, nHeight) && pcHead == script.end())
-        return error("MergedMiningHeader missing from parent coinbase");
 
     if (pc == script.end())
         return error("Aux POW missing chain merkle root in parent coinbase");

--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -37,7 +37,7 @@ public:
         nSerSize += SerReadWrite(s, parentBlock, nType | SER_BLOCKHEADERONLY, nVersion, ser_action);
     )
 
-    bool Check(uint256 hashAuxBlock, int nChainID, int nHeight);
+    bool Check(uint256 hashAuxBlock, int nChainID);
 
     uint256 GetParentBlockHash()
     {

--- a/src/gamestate.cpp
+++ b/src/gamestate.cpp
@@ -257,16 +257,6 @@ bool Move::IsValid(const GameState &state) const
 {
   PlayerStateMap::const_iterator mi = state.players.find (player);
 
-  /* Before the life-steal fork, check that the move does not contain
-     destruct and waypoints together.  This needs the height for its
-     decision, thus it is not done in Parse (as before).  */
-  /* FIXME: Remove check once the fork is passed.  */
-  if (!ForkInEffect (FORK_LIFESTEAL, state.nHeight + 1))
-    for (std::map<int, WaypointVector>::const_iterator i = waypoints.begin ();
-         i != waypoints.end (); ++i)
-      if (destruct.count (i->first) > 0)
-        return error ("%s: destruct and waypoints together", __func__);
-
   int64_t oldLocked;
   if (mi == state.players.end ())
     {

--- a/src/huntercoin.cpp
+++ b/src/huntercoin.cpp
@@ -2564,15 +2564,6 @@ CHuntercoinHooks::ConnectInputs (DatabaseSet& dbset,
               return error ("ConnectInputsHook: multiple name_update operations"
                             " on the same name");
 
-            /* Before the life-stealing fork, enforce that the coin
-               amount matches exactly.  Afterwards, we only require that
-               it is increasing over time (which is checked below).  */
-            /* FIXME: Remove check after the fork has passed.  */
-            if (!ForkInEffect (FORK_LIFESTEAL, pindexBlock->nHeight)
-                  && tx.vout[nOut].nValue != prevCoinAmount)
-              return error ("ConnectInputsHook: name_update tx:"
-                            " incorrect amount of the locked coin");
-
             /* Check that the locked amount is increasing over time.  The
                actual check for minimum fees is done by the move validation
                logic.  This is just an additional "safety net".  Note that

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1776,7 +1776,7 @@ bool CBlock::CheckProofOfWork(int nHeight) const
 
             if (auxpow->algo != algo)
                 return error("CheckProofOfWork() : AUX POW uses different algorithm");
-            if (!auxpow->Check(GetHash(), GetChainID(), nHeight))
+            if (!auxpow->Check(GetHash(), GetChainID()))
                 return error("CheckProofOfWork() : AUX POW is not valid");
             // Check proof of work matches claimed amount
             if (!::CheckProofOfWork(auxpow->GetParentBlockHash(), nBits, algo))
@@ -3730,9 +3730,7 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
         if (auxpow->algo != algo)
             return error("CheckWork() : AUX POW uses different algorithm");
 
-        /* FIXME: Remove this hack for nHeight when the fork has passed
-           and we no longer need it anyway.  */
-        if (!auxpow->Check(hashBlock, pblock->GetChainID(), nBestHeight + 1))
+        if (!auxpow->Check(hashBlock, pblock->GetChainID()))
             return error("AUX POW is not valid");
 
         uint256 hashParent = auxpow->GetParentBlockHash();


### PR DESCRIPTION
The checks were in place to disallow certain situations before the fork had passed.  These are now (after the fork) perfectly valid.  It is not really necessary to check for them anymore, since the chain is already past the fork point.

This is not urgent, but makes the code cleaner.  Please test a bit before merging, but it should be low-risk.
