### PR TITLE
set mainnet block height for timesave fork

### DIFF
--- a/huntercoin-qt.pro
+++ b/huntercoin-qt.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 TARGET = huntercoin-qt
 macx:TARGET = "HunterCoin-Qt"
-VERSION = 1.3.1
+VERSION = 1.4.0
 INCLUDEPATH += src src/json src/qt
 QT += network
 DEFINES += GUI QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,7 +101,7 @@ ForkInEffect (Fork type, unsigned nHeight)
       return nHeight >= (fTestNet ? 301000 : 795000);
 
     case FORK_TIMESAVE:
-      return nHeight >= (fTestNet ? 331500 : 1999999);
+      return nHeight >= (fTestNet ? 331500 : 1521500);
 
     default:
       assert (false);

--- a/src/main.h
+++ b/src/main.h
@@ -985,7 +985,9 @@ int ReadWriteAuxPow(Stream& s, const boost::shared_ptr<CAuxPow>& auxpow, int nTy
 enum
 {
     // primary version
-    BLOCK_VERSION_DEFAULT        = (1 << 0),
+    // (1 << 0) ... not FORK_TIMESAVE capable
+    // (1 << 1) ... FORK_TIMESAVE capable
+    BLOCK_VERSION_DEFAULT        = (1 << 1),
 
     // modifiers
     BLOCK_VERSION_AUXPOW         = (1 << 8),

--- a/src/qt/gamemapview.cpp
+++ b/src/qt/gamemapview.cpp
@@ -66,7 +66,7 @@ bool visualize_spawn_done = false;
 int visualize_nHeight;
 int visualize_x;
 int visualize_y;
-#define VISUALIZE_TIMESAVE_IN_EFFECT(H) (((fTestNet)&&(H>331500))||((!fTestNet)&&(H>1999999)))
+#define VISUALIZE_TIMESAVE_IN_EFFECT(H) (((fTestNet)&&(H>331500))||((!fTestNet)&&(H>1521500)))
 
 // Cache scene objects to avoid recreating them on each state update
 class GameMapCache

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -3,8 +3,8 @@ IDI_ICON1 ICON DISCARDABLE "icons/huntercoin.ico"
 #include <windows.h>             // needed for VERSIONINFO
 
 #define CLIENT_VERSION_MAJOR 1
-#define CLIENT_VERSION_MINOR 3
-#define CLIENT_VERSION_REVISION 1
+#define CLIENT_VERSION_MINOR 4
+#define CLIENT_VERSION_REVISION 0
 #define CLIENT_VERSION_BUILD 0
 
 // Converts the parameter X to a string after macro replacement on X has been performed.

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -37,7 +37,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int VERSION = 1030100;
+static const int VERSION = 1040000;
 static const char* pszSubVer = "";
 static const bool VERSION_IS_BETA = false;
 


### PR DESCRIPTION
Mainnet block height for timesave fork is 1521500.

Default block version for Huntercoin is changed from 1 to 2 (4 for Huntercore).
